### PR TITLE
Add basic web app and serial state machine

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,21 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # webserial-json
+
+This project demonstrates using the Web Serial API to send and receive JSON
+messages. The `SerialManager` class implements a small state machine that can
+connect to a serial port, send JSON encoded data, and dispatch received messages.
+A simple example web page lives in `public/`.
+
+## Development
+
+Tests use Node's built in test runner and can be executed with:
+
+```bash
+npm test
+```

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ Tests use Node's built in test runner and can be executed with:
 ```bash
 npm test
 ```
+
+## CI
+
+Tests are automatically run for pushes and pull requests using GitHub Actions.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "webserial-json",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WebSerial JSON</title>
+</head>
+<body>
+  <h1>WebSerial JSON Demo</h1>
+  <button id="connect">Connect</button>
+  <button id="disconnect" disabled>Disconnect</button>
+  <textarea id="output" rows="10" cols="50" readonly></textarea><br>
+  <input type="text" id="input" placeholder='{"hello":"world"}'>
+  <button id="send" disabled>Send</button>
+
+  <script type="module" src="./script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,38 @@
+import { SerialManager } from '../src/SerialManager.js';
+
+const output = document.getElementById('output');
+const input = document.getElementById('input');
+const connectBtn = document.getElementById('connect');
+const disconnectBtn = document.getElementById('disconnect');
+const sendBtn = document.getElementById('send');
+
+const manager = new SerialManager(navigator.serial, (msg) => {
+  output.value += JSON.stringify(msg) + '\n';
+});
+
+connectBtn.addEventListener('click', async () => {
+  try {
+    await manager.connect();
+    connectBtn.disabled = true;
+    disconnectBtn.disabled = false;
+    sendBtn.disabled = false;
+  } catch (e) {
+    alert(e.message);
+  }
+});
+
+disconnectBtn.addEventListener('click', async () => {
+  await manager.disconnect();
+  connectBtn.disabled = false;
+  disconnectBtn.disabled = true;
+  sendBtn.disabled = true;
+});
+
+sendBtn.addEventListener('click', async () => {
+  try {
+    const msg = JSON.parse(input.value);
+    await manager.send(msg);
+  } catch (e) {
+    alert('Invalid JSON');
+  }
+});

--- a/src/SerialManager.js
+++ b/src/SerialManager.js
@@ -1,0 +1,80 @@
+export const STATES = {
+  DISCONNECTED: 'disconnected',
+  CONNECTING: 'connecting',
+  CONNECTED: 'connected',
+  DISCONNECTING: 'disconnecting'
+};
+
+export class SerialManager {
+  constructor(serialInterface, messageHandler = () => {}, encoder = JSON.stringify, decoder = JSON.parse) {
+    this.serial = serialInterface;
+    this.messageHandler = messageHandler;
+    this.encoder = encoder;
+    this.decoder = decoder;
+    this.state = STATES.DISCONNECTED;
+    this.port = null;
+    this.reader = null;
+    this.writer = null;
+  }
+
+  async connect(options = { baudRate: 9600 }) {
+    if (this.state !== STATES.DISCONNECTED) {
+      throw new Error('Already connecting or connected');
+    }
+    this.state = STATES.CONNECTING;
+    try {
+      this.port = await this.serial.requestPort();
+      await this.port.open(options);
+      this.writer = this.port.writable.getWriter();
+      this.reader = this.port.readable.getReader();
+      this.state = STATES.CONNECTED;
+      this._readLoop();
+    } catch (err) {
+      this.state = STATES.DISCONNECTED;
+      throw err;
+    }
+  }
+
+  async _readLoop() {
+    try {
+      while (this.state === STATES.CONNECTED) {
+        const { value, done } = await this.reader.read();
+        if (done) break;
+        if (value) {
+          const text = new TextDecoder().decode(value);
+          try {
+            const message = this.decoder(text);
+            this.messageHandler(message);
+          } catch (e) {
+            // ignore decode errors
+          }
+        }
+      }
+    } catch (e) {
+      // reading stopped
+    }
+  }
+
+  async send(obj) {
+    if (this.state !== STATES.CONNECTED) {
+      throw new Error('Not connected');
+    }
+    const text = this.encoder(obj);
+    const data = new TextEncoder().encode(text);
+    await this.writer.write(data);
+  }
+
+  async disconnect() {
+    if (this.state !== STATES.CONNECTED) {
+      throw new Error('Not connected');
+    }
+    this.state = STATES.DISCONNECTING;
+    try {
+      await this.reader.cancel().catch(() => {});
+      this.reader.releaseLock();
+      await this.port.close();
+    } finally {
+      this.state = STATES.DISCONNECTED;
+    }
+  }
+}

--- a/test/fakeSerial.js
+++ b/test/fakeSerial.js
@@ -1,0 +1,35 @@
+export class FakePort {
+  constructor(queue = []) {
+    this.queue = queue; // incoming data chunks (Uint8Array)
+    this.sent = [];
+    this.readable = {
+      getReader: () => ({
+        read: async () => {
+          if (this.queue.length === 0) {
+            return { value: undefined, done: true };
+          }
+          return { value: this.queue.shift(), done: false };
+        },
+        releaseLock: () => {},
+        cancel: async () => {}
+      })
+    };
+    this.writable = {
+      getWriter: () => ({
+        write: async (data) => { this.sent.push(data); },
+        releaseLock: () => {}
+      })
+    };
+  }
+
+  async open() { this.opened = true; }
+  async close() { this.opened = false; }
+}
+
+export class FakeSerial {
+  constructor(port = new FakePort()) {
+    this.port = port;
+  }
+
+  async requestPort() { return this.port; }
+}

--- a/test/serial.test.js
+++ b/test/serial.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import { strictEqual, deepStrictEqual } from 'node:assert/strict';
+import { SerialManager, STATES } from '../src/SerialManager.js';
+import { FakeSerial, FakePort } from './fakeSerial.js';
+
+// helper to encode string to Uint8Array
+const enc = (str) => new TextEncoder().encode(str);
+
+test('state transitions and message handling', async (t) => {
+  const port = new FakePort([enc('{"foo":1}')]);
+  const serial = new FakeSerial(port);
+  const messages = [];
+  const manager = new SerialManager(serial, (msg) => messages.push(msg));
+
+  strictEqual(manager.state, STATES.DISCONNECTED);
+  await manager.connect();
+  strictEqual(manager.state, STATES.CONNECTED);
+
+  // process incoming message
+  await manager._readLoop();
+  deepStrictEqual(messages, [{ foo: 1 }]);
+
+  await manager.send({ bar: 2 });
+  strictEqual(port.sent.length, 1);
+  const sentText = new TextDecoder().decode(port.sent[0]);
+  strictEqual(sentText, '{"bar":2}');
+
+  await manager.disconnect();
+  strictEqual(manager.state, STATES.DISCONNECTED);
+});


### PR DESCRIPTION
## Summary
- bootstrap package.json with `node --test`
- add SerialManager and sample web UI
- implement fake serial for tests
- add node-based unit test for connecting and messaging
- document test command in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fc74121048330abb5f5c12117374b