### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,21 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./public
+      - uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ npm test
 ## CI
 
 Tests are automatically run for pushes and pull requests using GitHub Actions.
+
+The content of `public/` is also deployed to GitHub Pages via the `Deploy GitHub Pages` workflow whenever changes are pushed to `main` or the workflow is manually run.

--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ npm test
 
 Tests are automatically run for pushes and pull requests using GitHub Actions.
 
-The content of `public/` is also deployed to GitHub Pages via the `Deploy GitHub Pages` workflow whenever changes are pushed to `main` or the workflow is manually run.
+The content of `public/` is also deployed to GitHub Pages via the `Deploy GitHub Pages` workflow whenever changes are pushed to `main` or the workflow is manually run. You can view the site at <https://ehunck.github.io/webserial-json/>.


### PR DESCRIPTION
## Summary
- add a workflow to deploy `public/` to GitHub Pages
- document the new deployment workflow in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fc99fa52c83308fcb258c40b82ad9