### PR TITLE
Improve UI layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,15 +8,42 @@
     * {
       box-sizing: border-box;
     }
-    body {
+    html, body {
+      height: 100%;
       margin: 0;
-      padding: 1rem;
       font-family: system-ui, sans-serif;
+    }
+
+    #app {
+      display: grid;
+      grid-template-columns: 50px 1fr;
+      grid-template-rows: 1fr auto;
+      height: 100%;
+    }
+
+    #sidebar {
+      grid-row: 1 / span 2;
+      background: #333;
+      color: #fff;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 0.5rem 0;
+    }
+
+    #main {
+      padding: 1rem;
+      overflow: auto;
       display: flex;
       flex-direction: column;
       gap: 1rem;
-      max-width: 800px;
-      margin-inline: auto;
+    }
+
+    #status {
+      background: #007acc;
+      color: #fff;
+      padding: 0.25rem 0.5rem;
+      font-size: 0.9rem;
     }
 
     #controls {
@@ -74,23 +101,31 @@
   </style>
 </head>
 <body>
-  <h1>WebSerial JSON Demo</h1>
+  <div id="app">
+    <div id="sidebar">
+      <div class="tab active">Demo</div>
+    </div>
+    <div id="main">
+      <h1>WebSerial JSON Demo</h1>
 
-  <div id="controls">
-    <button id="connect">Connect</button>
-    <button id="disconnect" disabled>Disconnect</button>
-  </div>
-  <textarea id="output" rows="10" cols="50" readonly></textarea>
+      <div id="controls">
+        <button id="connect">Connect</button>
+        <button id="disconnect" disabled>Disconnect</button>
+      </div>
+      <textarea id="output" rows="10" cols="50" readonly></textarea>
 
-  <div id="builder">
-    <h2>Build JSON</h2>
-    <div id="fields"></div>
-    <button id="add-field" type="button">Add Field</button>
-  </div>
+      <div id="builder">
+        <h2>Build JSON</h2>
+        <div id="fields"></div>
+        <button id="add-field" type="button">Add Field</button>
+      </div>
 
-  <div id="send-controls">
-    <textarea id="input" rows="5" cols="50" placeholder='{"hello":"world"}'></textarea>
-    <button id="send" disabled>Send</button>
+      <div id="send-controls">
+        <textarea id="input" rows="5" cols="50" placeholder='{"hello":"world"}'></textarea>
+        <button id="send" disabled>Send</button>
+      </div>
+    </div>
+    <div id="status">Disconnected</div>
   </div>
   <script type="module" src="./script.js"></script>
 </body>

--- a/public/script.js
+++ b/public/script.js
@@ -7,10 +7,17 @@ const disconnectBtn = document.getElementById('disconnect');
 const sendBtn = document.getElementById('send');
 const fieldsDiv = document.getElementById('fields');
 const addFieldBtn = document.getElementById('add-field');
+const statusBar = document.getElementById('status');
+
+function setStatus(text) {
+  statusBar.textContent = text;
+}
 
 const manager = new SerialManager(navigator.serial, (msg) => {
   output.value += JSON.stringify(msg) + '\n';
 });
+
+setStatus('Disconnected');
 
 function createBuilder(isArray) {
   const container = document.createElement('div');
@@ -162,11 +169,14 @@ updatePreview();
 
 connectBtn.addEventListener('click', async () => {
   try {
+    setStatus('Connecting...');
     await manager.connect();
     connectBtn.disabled = true;
     disconnectBtn.disabled = false;
     sendBtn.disabled = false;
+    setStatus('Connected');
   } catch (e) {
+    setStatus('Disconnected');
     alert(e.message);
   }
 });
@@ -176,6 +186,7 @@ disconnectBtn.addEventListener('click', async () => {
   connectBtn.disabled = false;
   disconnectBtn.disabled = true;
   sendBtn.disabled = true;
+  setStatus('Disconnected');
 });
 
 sendBtn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- add VS Code-inspired layout with sidebar, main area, and status bar
- update script to drive connection status display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fd11031a08330bb5b2741d023fd25