### PR TITLE
Add TX and RX workspace pages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -135,12 +135,23 @@
       gap: 0.5rem;
       align-items: flex-start;
     }
+
+    .page {
+      display: none;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .page.active {
+      display: flex;
+    }
   </style>
 </head>
 <body>
   <div id="app">
     <div id="sidebar">
-      <div class="tab active">Demo</div>
+      <div class="tab active" id="tab-tx" title="Transmit">📤</div>
+      <div class="tab" id="tab-rx" title="Receive">📥</div>
     </div>
     <div id="main">
       <h1>WebSerial JSON Demo</h1>
@@ -149,17 +160,22 @@
         <button id="connect">Connect</button>
         <button id="disconnect" disabled>Disconnect</button>
       </div>
-      <textarea id="output" rows="10" cols="50" readonly></textarea>
 
-      <div id="builder">
-        <h2>Build JSON</h2>
-        <div id="fields"></div>
-        <button id="add-field" type="button">Add Field</button>
+      <div id="tx-page" class="page active">
+        <div id="builder">
+          <h2>Build JSON</h2>
+          <div id="fields"></div>
+          <button id="add-field" type="button">Add Field</button>
+        </div>
+
+        <div id="send-controls">
+          <textarea id="input" rows="5" cols="50" placeholder='{"hello":"world"}'></textarea>
+          <button id="send" disabled>Send</button>
+        </div>
       </div>
 
-      <div id="send-controls">
-        <textarea id="input" rows="5" cols="50" placeholder='{"hello":"world"}'></textarea>
-        <button id="send" disabled>Send</button>
+      <div id="rx-page" class="page">
+        <textarea id="output" rows="10" cols="50" readonly></textarea>
       </div>
     </div>
     <div id="status">Disconnected</div>

--- a/public/script.js
+++ b/public/script.js
@@ -8,6 +8,10 @@ const sendBtn = document.getElementById('send');
 const fieldsDiv = document.getElementById('fields');
 const addFieldBtn = document.getElementById('add-field');
 const statusBar = document.getElementById('status');
+const tabTx = document.getElementById('tab-tx');
+const tabRx = document.getElementById('tab-rx');
+const txPage = document.getElementById('tx-page');
+const rxPage = document.getElementById('rx-page');
 
 function setStatus(text) {
   statusBar.textContent = text;
@@ -18,6 +22,16 @@ const manager = new SerialManager(navigator.serial, (msg) => {
 });
 
 setStatus('Disconnected');
+
+function showPage(page) {
+  txPage.classList.toggle('active', page === 'tx');
+  rxPage.classList.toggle('active', page === 'rx');
+  tabTx.classList.toggle('active', page === 'tx');
+  tabRx.classList.toggle('active', page === 'rx');
+}
+
+tabTx.addEventListener('click', () => showPage('tx'));
+tabRx.addEventListener('click', () => showPage('rx'));
 
 function createBuilder(isArray) {
   const container = document.createElement('div');


### PR DESCRIPTION
## Summary
- add sidebar icons for TX/RX pages
- show separate TX builder and RX output pages
- include page switching logic in script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684080004810833090dc0373c575cb5d