### PR TITLE
Fix disconnect error by releasing writer

### DIFF
--- a/src/SerialManager.js
+++ b/src/SerialManager.js
@@ -72,6 +72,9 @@ export class SerialManager {
     try {
       await this.reader.cancel().catch(() => {});
       this.reader.releaseLock();
+      if (this.writer) {
+        this.writer.releaseLock();
+      }
       await this.port.close();
     } finally {
       this.state = STATES.DISCONNECTED;


### PR DESCRIPTION
## Summary
- release writer lock before closing the port

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684081bdfca883308fce05cb1520395a