### PR TITLE
Fix SerialManager disconnect

### DIFF
--- a/test/serial.test.js
+++ b/test/serial.test.js
@@ -17,7 +17,7 @@ test('state transitions and message handling', async (t) => {
   strictEqual(manager.state, STATES.CONNECTED);
 
   // process incoming message
-  await manager._readLoop();
+  await manager.readLoopPromise;
   deepStrictEqual(messages, [{ foo: 1 }]);
 
   await manager.send({ bar: 2 });


### PR DESCRIPTION
## Summary
- ensure the read loop finishes before closing a serial port
- wait for the read loop in the test suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684082a7954c8330972a96445fd5767d