### PR TITLE
Fix sidebar width and remove duplicate controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -31,7 +31,7 @@
 
     #app {
       display: grid;
-      grid-template-columns: 50px 1fr;
+      grid-template-columns: 120px 1fr;
       grid-template-rows: 1fr auto;
       height: 100%;
     }
@@ -59,11 +59,6 @@
       color: var(--status-fg);
       padding: 0.25rem 0.5rem;
       font-size: 0.9rem;
-    }
-
-    #controls {
-      display: flex;
-      gap: 0.5rem;
     }
 
     #sidebar-controls {
@@ -157,8 +152,8 @@
 <body>
   <div id="app">
     <div id="sidebar">
-      <div class="tab active" id="tab-tx" title="Transmit">📤</div>
-      <div class="tab" id="tab-rx" title="Receive">📥</div>
+      <div class="tab active" id="tab-tx" title="Transmit">&#x2191;</div>
+      <div class="tab" id="tab-rx" title="Receive">&#x2193;</div>
       <div id="sidebar-controls">
         <button id="side-connect">Connect</button>
         <button id="side-disconnect" disabled>Disconnect</button>
@@ -166,11 +161,6 @@
     </div>
     <div id="main">
       <h1 id="title">Transmit</h1>
-
-      <div id="controls">
-        <button id="connect">Connect</button>
-        <button id="disconnect" disabled>Disconnect</button>
-      </div>
 
       <div id="tx-page" class="page active">
         <div id="builder">

--- a/public/script.js
+++ b/public/script.js
@@ -193,9 +193,9 @@ async function handleConnect() {
   try {
     setStatus('Connecting...');
     await manager.connect();
-    connectBtn.disabled = true;
+    if (connectBtn) connectBtn.disabled = true;
     sideConnectBtn.disabled = true;
-    disconnectBtn.disabled = false;
+    if (disconnectBtn) disconnectBtn.disabled = false;
     sideDisconnectBtn.disabled = false;
     sendBtn.disabled = false;
     setStatus('Connected');
@@ -207,18 +207,18 @@ async function handleConnect() {
 
 async function handleDisconnect() {
   await manager.disconnect();
-  connectBtn.disabled = false;
+  if (connectBtn) connectBtn.disabled = false;
   sideConnectBtn.disabled = false;
-  disconnectBtn.disabled = true;
+  if (disconnectBtn) disconnectBtn.disabled = true;
   sideDisconnectBtn.disabled = true;
   sendBtn.disabled = true;
   setStatus('Disconnected');
 }
 
-connectBtn.addEventListener('click', handleConnect);
+if (connectBtn) connectBtn.addEventListener('click', handleConnect);
 sideConnectBtn.addEventListener('click', handleConnect);
 
-disconnectBtn.addEventListener('click', handleDisconnect);
+if (disconnectBtn) disconnectBtn.addEventListener('click', handleDisconnect);
 sideDisconnectBtn.addEventListener('click', handleDisconnect);
 
 sendBtn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- widen sidebar
- remove redundant connect/disconnect controls from main area
- replace missing sidebar icons with simple arrows
- guard connect/disconnect logic when main buttons are absent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840bd3e1f548330ae2bab797893e64c